### PR TITLE
feat: Replace year filter with commemorative series filter and add co…

### DIFF
--- a/app/models/coin.py
+++ b/app/models/coin.py
@@ -29,5 +29,5 @@ class StatsResponse(BaseModel):
 
 class FilterOptions(BaseModel):
     countries: List[str]
-    years: List[int]
+    commemoratives: List[str]
     denominations: List[float]

--- a/app/routers/coins.py
+++ b/app/routers/coins.py
@@ -11,8 +11,9 @@ bigquery_service = BigQueryService()
 @router.get("/", response_model=CoinListResponse)
 async def get_coins(
     coin_type: Optional[str] = Query(None, description="Filter by coin type (RE/CC)"),
+    value: Optional[float] = Query(None, description="Filter by coin value"),
     country: Optional[str] = Query(None, description="Filter by country"),
-    year: Optional[int] = Query(None, description="Filter by year"),
+    commemorative: Optional[str] = Query(None, description="Filter by commemorative series"),
     search: Optional[str] = Query(None, description="Search term"),
     limit: int = Query(20, ge=1, le=2000, description="Results per page"),
     offset: int = Query(0, ge=0, description="Pagination offset")
@@ -22,10 +23,12 @@ async def get_coins(
         filters = {}
         if coin_type:
             filters['coin_type'] = coin_type
+        if value:
+            filters['value'] = value
         if country:
             filters['country'] = country
-        if year:
-            filters['year'] = year
+        if commemorative:
+            filters['series'] = commemorative
 
         coins_data = await bigquery_service.get_coins(filters, limit, offset)
         

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -42,6 +42,15 @@
                     </select>
                 </div>
                 
+                <!-- Coin Value Filter -->
+                <div class="filter-section">
+                    <label for="value-filter" class="form-label">Coin Value</label>
+                    <select class="form-select" id="value-filter">
+                        <option value="">All Values</option>
+                        <!-- Options will be populated by JavaScript -->
+                    </select>
+                </div>
+                
                 <!-- Country Filter -->
                 <div class="filter-section">
                     <label for="country-filter" class="form-label">Country</label>
@@ -51,11 +60,11 @@
                     </select>
                 </div>
                 
-                <!-- Year Filter -->
+                <!-- Commemorative Filter -->
                 <div class="filter-section">
-                    <label for="year-filter" class="form-label">Year</label>
-                    <select class="form-select" id="year-filter">
-                        <option value="">All Years</option>
+                    <label for="commemorative-filter" class="form-label">€2 Commemoratives</label>
+                    <select class="form-select" id="commemorative-filter">
+                        <option value="">All Commemoratives</option>
                         <!-- Options will be populated by JavaScript -->
                     </select>
                 </div>


### PR DESCRIPTION
…in value filter

- Replace year filter with commemorative series filter showing only CC series
- Add new coin value filter after coin type filter
- Create user-friendly labels for commemorative series (e.g., '2024 - €2 Commemoratives')
- Sort commemorative series in descending order (most recent first)
- Format coin values with two decimal places (e.g., €2.00, €0.01)
- Update backend API to support series and value filtering
- Update frontend JavaScript with proper filtering logic and event handlers

Changes include:
- Backend: Updated BigQuery service, router, and models
- Frontend: Updated HTML template and JavaScript for new filters
- UI: Improved user experience with better labeling and formatting