### PR TITLE
feat: Add ownership badges to coin cards in groups mode

### DIFF
--- a/OWNERSHIP_BADGE_IMPLEMENTATION.md
+++ b/OWNERSHIP_BADGE_IMPLEMENTATION.md
@@ -1,0 +1,139 @@
+# Ownership Badge Implementation 🏷️
+
+## Overview
+Added ownership badges to coin cards in groups mode to show ownership information at a glance.
+
+## Features Implemented
+
+### 📍 Badge Placement
+- **Location**: Upper right corner of coin image
+- **Style**: Similar to coin type badge (top-left) but positioned on the right
+- **Visibility**: Only visible in groups mode
+- **Color**: Green (success) background to match owner name badges
+
+### 🎯 Badge Logic (3 Cases)
+
+#### Case 1: No Ownership (0 owners)
+- **Display**: No badge shown
+- **Condition**: `coin.owners.length === 0`
+- **Rationale**: Clean appearance when no one owns the coin
+
+#### Case 2: Partial Ownership (1 to group_members-1 owners)
+- **Display**: Number badge showing count of owners
+- **Style**: Green success badge with white text
+- **Example**: `3` (meaning 3 out of 8 members own this coin)
+- **Tooltip**: "Owned by X/Y members"
+
+#### Case 3: Full Ownership (everyone owns it)
+- **Display**: Three star badge (⭐⭐⭐)
+- **Style**: Green success badge with white text and pulse animation
+- **Condition**: `coin.owners.length === totalMembers`
+- **Tooltip**: "Owned by everyone (X/Y)"
+
+## Implementation Details
+
+### JavaScript (`static/js/coins.js`)
+```javascript
+// Generate ownership badge for upper right corner if in group mode
+let ownershipBadgeHtml = '';
+if (this.groupContext && coin.owners !== undefined) {
+    const ownersCount = coin.owners ? coin.owners.length : 0;
+    const totalMembers = this.groupContext.members ? this.groupContext.members.length : 0;
+    
+    if (ownersCount > 0) {
+        if (ownersCount === totalMembers) {
+            // Everyone owns it - show stars badge
+            ownershipBadgeHtml = `
+                <span class="badge bg-warning text-dark position-absolute top-0 end-0 m-2 ownership-badge" title="Owned by everyone">
+                    ⭐⭐⭐
+                </span>
+            `;
+        } else {
+            // Show number of owners
+            ownershipBadgeHtml = `
+                <span class="badge bg-info text-white position-absolute top-0 end-0 m-2 ownership-badge" title="Owned by ${ownersCount} member${ownersCount > 1 ? 's' : ''}">
+                    ${ownersCount}
+                </span>
+            `;
+        }
+    }
+    // No badge for 0 owners (case 1)
+}
+```
+
+### CSS Styling (`static/css/style.css`)
+```css
+/* Ownership badge in upper right corner */
+.ownership-badge {
+    font-size: 0.75rem !important;
+    font-weight: 600 !important;
+    min-width: 24px;
+    height: 24px;
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    border-radius: 12px !important;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    z-index: 10;
+}
+
+/* Special styling for the "everyone owns" badge */
+.ownership-badge.bg-warning {
+    background-color: #ffc107 !important;
+    color: #212529 !important;
+    font-size: 0.7rem !important;
+    padding: 0.2rem 0.4rem !important;
+    border-radius: 8px !important;
+}
+
+/* Numeric ownership badge */
+.ownership-badge.bg-info {
+    background-color: #0dcaf0 !important;
+    color: white !important;
+}
+```
+
+## Testing
+
+### Test Cases
+1. **Group with 8 members** (hippo group)
+2. **Coins with 0 owners** → No badge
+3. **Coins with 1-7 owners** → Number badge (1, 2, 3, etc.)
+4. **Coins with 8 owners** → Star badge (⭐⭐⭐)
+
+### How to Test
+1. Navigate to: `http://localhost:8000/hippo/catalog`
+2. Observe coin cards:
+   - **No badge**: Coins not owned by anyone
+   - **Number badges**: Coins owned by some members
+   - **Star badges**: Coins owned by all 8 members
+
+## User Experience
+
+### Visual Hierarchy
+- **Top-left**: Coin type (RE/CC)
+- **Top-right**: Ownership count (when applicable)
+- **Card body**: Detailed ownership information (existing)
+
+### Color Coding
+- **Green (success)**: Both partial and full ownership (matches owner name badges)
+- **No badge**: No ownership
+
+### Accessibility
+- **Tooltips**: Descriptive text on hover
+- **High contrast**: Readable white text on green background
+- **Semantic colors**: Consistent with owner name badges
+
+## Benefits
+
+1. **Quick Overview**: Instant visibility of ownership status
+2. **Visual Scanning**: Easy to spot popular coins (high numbers/stars)
+3. **Collecting Strategy**: Identify opportunities (missing coins vs. popular coins)
+4. **Group Dynamics**: See collection patterns across members
+
+## Future Enhancements
+
+- Add click functionality to show owner details
+- Color gradients based on ownership percentage
+- Animation effects for full ownership
+- Filter by ownership level in sidebar

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -641,6 +641,55 @@
     background-color: transparent;
 }
 
+/* Ownership badge in upper right corner */
+.ownership-badge {
+    font-size: 0.75rem !important;
+    font-weight: 600 !important;
+    min-width: 24px;
+    height: 24px;
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    border-radius: 12px !important;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    z-index: 10;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ownership-badge:hover {
+    transform: scale(1.1);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* Special styling for the "everyone owns" badge - keep success color */
+.ownership-badge.ownership-full {
+    background-color: #198754 !important;
+    color: white !important;
+    font-size: 0.65rem !important;
+    padding: 0.2rem 0.4rem !important;
+    border-radius: 8px !important;
+    animation: pulse-success 2s infinite;
+}
+
+/* Numeric ownership badge - success color to match owner badges */
+.ownership-badge.ownership-partial {
+    background-color: #198754 !important;
+    color: white !important;
+}
+
+/* Pulse animation for full ownership - updated to use success color */
+@keyframes pulse-success {
+    0% {
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    50% {
+        box-shadow: 0 4px 12px rgba(25, 135, 84, 0.4);
+    }
+    100% {
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+}
+
 /* Group filter sections */
 .filter-section h6 {
     color: var(--primary-color);

--- a/static/js/coins.js
+++ b/static/js/coins.js
@@ -281,7 +281,34 @@ class CoinCatalog {
         // Format value to always show 2 decimal places
         const formattedValue = parseFloat(coin.value).toFixed(2);
 
-        // Generate ownership badges if in group mode
+        // Generate ownership badge for upper right corner if in group mode
+        let ownershipBadgeHtml = '';
+        
+        if (this.groupContext && coin.owners !== undefined) {
+            const ownersCount = coin.owners ? coin.owners.length : 0;
+            const totalMembers = this.groupContext.members ? this.groupContext.members.length : 0;
+            
+            if (ownersCount > 0) {
+                if (ownersCount === totalMembers) {
+                    // Everyone owns it - show stars badge with success color
+                    ownershipBadgeHtml = `
+                        <span class="badge bg-success text-white position-absolute top-0 end-0 m-2 ownership-badge ownership-full" title="Owned by everyone (${ownersCount}/${totalMembers})">
+                            ⭐⭐⭐
+                        </span>
+                    `;
+                } else {
+                    // Show number of owners with success color
+                    ownershipBadgeHtml = `
+                        <span class="badge bg-success text-white position-absolute top-0 end-0 m-2 ownership-badge ownership-partial" title="Owned by ${ownersCount}/${totalMembers} members">
+                            ${ownersCount}
+                        </span>
+                    `;
+                }
+            }
+            // No badge for 0 owners (case 1)
+        }
+
+        // Generate ownership info in card body (keep existing functionality)
         let ownershipHtml = '';
         if (this.groupContext && coin.owners) {
             if (coin.owners.length > 0) {
@@ -316,6 +343,7 @@ class CoinCatalog {
                         <span class="badge ${typeClass} position-absolute top-0 start-0 m-2">
                             ${coin.coin_type}
                         </span>
+                        ${ownershipBadgeHtml}
                     </div>
                     <div class="card-body coin-card-clickable" data-coin-id="${coin.coin_id}" style="cursor: pointer;">
                         <div class="d-flex justify-content-between align-items-center mb-2">


### PR DESCRIPTION
- Add ownership badge in upper right corner of coin cards
- Show numeric badge for partial ownership (1 to n-1 members)
- Show star badge (⭐⭐⭐) for full ownership (everyone owns)
- No badge for zero ownership
- Use green (success) color to match owner name badges
- Add hover effects and pulse animation for full ownership
- Include comprehensive documentation

Features:
- Visual consistency with existing owner badges
- Responsive design with proper positioning
- Informative tooltips showing ownership ratios
- Clean implementation in JavaScript and CSS