### PR TITLE
Fix group filters functionality

### DIFF
--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -88,8 +88,8 @@
 
                 <!-- Group Members Filter -->
                 <div class="filter-section">
-                    <label for="member-filter" class="form-label">Group Members</label>
-                    <select class="form-select" id="member-filter">
+                    <label for="owned-by-filter" class="form-label">Group Members</label>
+                    <select class="form-select" id="owned-by-filter">
                         <option value="">All Members</option>
                         {% for member in group_context.members %}
                         <option value="{{ member.user }}">{{ member.alias }}</option>


### PR DESCRIPTION
- Fixed ID mismatch between HTML (member-filter) and JS (owned-by-filter)
- Added client-side filtering for group-specific filters (ownership_status, owned_by)
- Added populateGroupMemberFilter() method to populate member dropdown
- Added clearAllFilters() method with support for group filters
- Added clear filters button event handler
- Group filters now work properly for both owned/missing status and specific member filtering