### PR TITLE
fix: improve navbar group badge alignment and remove extra > character

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm border-bottom sticky-top">
         <div class="container position-relative">
-            <a class="navbar-brand d-flex align-items-center" href="{% if group_context %}/{{ group_context.group_key }}{% else %}/{% endif %}">>
+            <a class="navbar-brand d-flex align-items-center" href="{% if group_context %}/{{ group_context.group_key }}{% else %}/{% endif %}">
                 <div class="coin-logo me-3 d-flex align-items-center justify-content-center" 
                      style="width: 40px; height: 40px; border-radius: 50%; overflow: hidden;">
                     <img src="/static/images/myeurocoins-icon.png" alt="My EuroCoins" style="width: 36px; height: 36px;">
@@ -53,21 +53,20 @@
                 </div>
             </a>
             
-            <!-- Group Indicator (top-right corner) -->
-            {% if group_context %}
-            <div class="group-indicator position-absolute top-50 end-0 translate-middle-y me-3">
-                <span class="badge bg-primary fs-6">
-                    <i class="fas fa-users me-2"></i>{{ group_context.name }}
-                </span>
-            </div>
-            {% endif %}
-            
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>
             </button>
             
             <div class="collapse navbar-collapse" id="navbarNav">
                 <div class="navbar-nav ms-auto">
+                    <!-- Group Indicator -->
+                    {% if group_context %}
+                    <div class="nav-item d-flex align-items-center me-3">
+                        <span class="badge bg-primary fs-6">
+                            <i class="fas fa-users me-2"></i>{{ group_context.name }}
+                        </span>
+                    </div>
+                    {% endif %}
                     <a class="nav-link fw-medium" href="{% if group_context %}/{{ group_context.group_key }}{% else %}/{% endif %}">
                         <i class="fas fa-home me-1"></i>Home
                     </a>


### PR DESCRIPTION
- Remove extra '>' character from navbar brand anchor tag
- Move group indicator from absolute positioning to navbar flow
- Integrate group badge as proper nav-item for better alignment
- Remove overlapping issues between group badge and navigation links