### PR TITLE
feat: implement export active history button with date and name sorting

### DIFF
--- a/app/services/bigquery_service.py
+++ b/app/services/bigquery_service.py
@@ -1234,7 +1234,8 @@ class BigQueryService:
             h.name, 
             COALESCE(h.coin_id, h.id) as id,  -- Use coin_id if available, fallback to id for legacy data
             h.date,
-            h.created_at
+            h.created_at,
+            h.is_active
         FROM `{self.client.project}.{self.dataset_id}.{settings.bq_history_table}` h
         ORDER BY h.created_at DESC
         """

--- a/app/services/history_service.py
+++ b/app/services/history_service.py
@@ -232,5 +232,11 @@ class HistoryService:
 
         export_df = df_latest[['name', 'id', 'date']].copy()
         export_df['date'] = pd.to_datetime(export_df['date']).dt.strftime('%Y-%m-%d %H:%M:%S')
+        
+        # Sort by date (without time) DESC, then by name ASC
+        export_df['date_dt'] = pd.to_datetime(export_df['date'])
+        export_df['date_only'] = export_df['date_dt'].dt.date
+        export_df = export_df.sort_values(['date_only', 'name'], ascending=[False, True])
+        export_df = export_df.drop(columns=['date_dt', 'date_only'])
 
         return export_df

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -1733,21 +1733,15 @@ async function exportHistoryCsv() {
     exportBtn.disabled = true;
 
     try {
-        // We only export currently owned coins for a specific user to match requirements
-        const selectedName = document.getElementById('filterHistoryName').value;
-        if (!selectedName) {
-            showAlert('Please select a user from the Name filter before exporting.', 'warning');
-            return;
-        }
-
-        const response = await fetch(`/api/admin/history/export?name=${encodeURIComponent(selectedName)}`);
+        // Export all active history (no name filter needed)
+        const response = await fetch('/api/admin/history/export');
         
         if (response.ok) {
             const blob = await response.blob();
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
-            a.download = `${selectedName}_owned_coins.csv`;
+            a.download = 'history.csv';
             document.body.appendChild(a);
             a.click();
             window.URL.revokeObjectURL(url);

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -362,7 +362,7 @@
                                                 <i class="fas fa-cloud-upload-alt me-1"></i>Upload and Analyze
                                             </button>
                                             <button type="button" class="btn btn-outline-success ms-2" id="exportHistoryCsvBtn">
-                                                <i class="fas fa-download me-1"></i>Export All History to CSV
+                                                <i class="fas fa-download me-1"></i>Export History to CSV
                                             </button>
                                         </div>
                                     </div>


### PR DESCRIPTION
- Add export button for all active history records on admin page
- Filter to include only coins with last status as active
- Sort by date (without time) DESC, then by name ASC
- Format: name,id,date
- Update BigQuery service to include is_active field
- Modify admin.js to export all active history without user filter